### PR TITLE
[Feat] 카카오 로그인 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,5 +36,19 @@
         <data android:scheme="drivemate" />
       </intent-filter>
     </activity>
+
+    <activity 
+      android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <!-- Redirect URI: "kakao{NATIVE_APP_KEY}://oauth“ -->
+        <data android:host="oauth"
+          android:scheme="kakaoe7b5c13052c473f0ae078888168e6665" />
+      </intent-filter>
+    </activity>
   </application>
 </manifest>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">drivemate</string>
+    <string name="kakao_app_key">e7b5c13052c473f0ae078888168e6665</string>
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,5 +37,7 @@ allprojects {
         google()
         mavenCentral()
         maven { url 'https://www.jitpack.io' }
+        maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
+
     }
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -53,6 +53,14 @@ const Splash = () => {
       >
         <Text>voicechat</Text>
       </Link>
+
+      <Link
+        href={{
+          pathname: "/kakao",
+        }}
+      >
+        <Text>kakao</Text>
+      </Link>
     </View>
   );
 };

--- a/app/kakao.tsx
+++ b/app/kakao.tsx
@@ -1,0 +1,122 @@
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import React, { useState } from "react";
+import {
+  login,
+  logout,
+  getProfile as getKakaoProfile,
+  shippingAddresses as getKakaoShippingAddresses,
+  unlink,
+} from "@react-native-seoul/kakao-login";
+
+const Kakao = () => {
+  const [result, setResult] = useState<string>("");
+
+  const signInWithKakao = async (): Promise<void> => {
+    try {
+      const token = await login();
+      setResult(JSON.stringify(token));
+      console.log("login success ", token.accessToken);
+    } catch (err) {
+      console.error("login err", err);
+    }
+  };
+
+  const signOutWithKakao = async (): Promise<void> => {
+    try {
+      const message = await logout();
+
+      setResult(message);
+    } catch (err) {
+      console.error("signOut error", err);
+    }
+  };
+
+  const getProfile = async (): Promise<void> => {
+    try {
+      const profile = await getKakaoProfile();
+
+      setResult(JSON.stringify(profile));
+    } catch (err) {
+      console.error("signOut error", err);
+    }
+  };
+
+  const getShippingAddresses = async (): Promise<void> => {
+    try {
+      const shippingAddresses = await getKakaoShippingAddresses();
+
+      setResult(JSON.stringify(shippingAddresses));
+    } catch (err) {
+      console.error("signOut error", err);
+    }
+  };
+
+  const unlinkKakao = async (): Promise<void> => {
+    try {
+      const message = await unlink();
+
+      setResult(message);
+    } catch (err) {
+      console.error("signOut error", err);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.resultContainer}>
+        <ScrollView>
+          <Text>{result}</Text>
+        </ScrollView>
+      </View>
+      <Pressable
+        style={styles.button}
+        onPress={() => {
+          signInWithKakao();
+        }}
+      >
+        <Text style={styles.text}>카카오 로그인</Text>
+      </Pressable>
+      <Pressable style={styles.button} onPress={() => getProfile()}>
+        <Text style={styles.text}>프로필 조회</Text>
+      </Pressable>
+      <Pressable style={styles.button} onPress={() => getShippingAddresses()}>
+        <Text style={styles.text}>배송주소록 조회</Text>
+      </Pressable>
+      <Pressable style={styles.button} onPress={() => unlinkKakao()}>
+        <Text style={styles.text}>링크 해제</Text>
+      </Pressable>
+      <Pressable style={styles.button} onPress={() => signOutWithKakao()}>
+        <Text style={styles.text}>카카오 로그아웃</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+export default Kakao;
+
+const styles = StyleSheet.create({
+  container: {
+    height: "100%",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    paddingBottom: 100,
+  },
+  resultContainer: {
+    flexDirection: "column",
+    width: "100%",
+    padding: 24,
+  },
+  button: {
+    backgroundColor: "#FEE500",
+    borderRadius: 40,
+    borderWidth: 1,
+    width: 250,
+    height: 40,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    marginTop: 10,
+  },
+  text: {
+    textAlign: "center",
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@crossplatformkorea/expo-stt": "^0.0.4",
         "@react-native-picker/picker": "^2.11.0",
+        "@react-native-seoul/kakao-login": "^5.4.1",
         "axios": "^1.7.9",
         "expo": "~52.0.28",
         "expo-audio": "~0.3.4",
@@ -3047,6 +3048,19 @@
         "react-native": "*"
       }
     },
+    "node_modules/@react-native-seoul/kakao-login": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@react-native-seoul/kakao-login/-/kakao-login-5.4.1.tgz",
+      "integrity": "sha512-ezhkX3AsJZ3Qf3b0QDJEpPIvWDqxuz2N9lKd9g90ULpzaYa+d0r7UdfCe4h+/Fo859t7t0vFSXqIbLLIHSlxFw==",
+      "license": "MIT",
+      "dependencies": {
+        "dooboolab-welcome": "^1.3.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.76.6",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.76.6.tgz",
@@ -5173,6 +5187,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dooboolab-welcome": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dooboolab-welcome/-/dooboolab-welcome-1.3.2.tgz",
+      "integrity": "sha512-2NbMaIIURElxEf/UAoVUFlXrO+7n/FRhLCiQlk4fkbGRh9cJ3/f8VEMPveR9m4Ug2l2Zey+UCXjd6EcBqHJ5bw==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "bin": {
+        "dooboolab-welcome": "bin/hello.js"
       }
     },
     "node_modules/dotenv": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@crossplatformkorea/expo-stt": "^0.0.4",
     "@react-native-picker/picker": "^2.11.0",
+    "@react-native-seoul/kakao-login": "^5.4.1",
     "axios": "^1.7.9",
     "expo": "~52.0.28",
     "expo-audio": "~0.3.4",


### PR DESCRIPTION
## 🔥 Issues
#11 

## ✅ What to do

- [x] 카카오 로그인 구현

## 📄 Description
![image](https://github.com/user-attachments/assets/d98eaa7e-3b61-4274-9847-1a06f5e4bced)
![image](https://github.com/user-attachments/assets/db78fe82-79f9-4943-99ee-8ac969418249)
![image](https://github.com/user-attachments/assets/571b1efd-e4e5-438a-8f22-bb52a60c74f4)

## 🤔 Considerations
- 전체 흐름
FE) 카카오 로그인 구현 → 카카오에서 토큰(accessToken, refreshToken) 발급 받기 → 토큰 BE로 넘기기
BE) 사용자 인증 후 DB 저장 → 자체 토큰 FE로 발급
FE) 회원가입 여부에 따라 리다이렉트 + 토큰 앱 스토리지에 저장

백에서 API 명세서 작성해주면 토큰 BE로 넘겨야한다.
현재 테스트 코드 복붙해서 확인 -> 나중에 카카오로 시작하기 버튼으로 코드 수정해야 한다.

## 👀 References
- 작성한 블로그
https://ansui218.tistory.com/161