### PR TITLE
[Feat] 카카오 로그인 및 로그아웃 구현

### DIFF
--- a/app/myinfo.tsx
+++ b/app/myinfo.tsx
@@ -3,13 +3,15 @@ import { Text, View, TouchableOpacity, ScrollView } from "react-native";
 
 import Header from "@/components/Header";
 import Custom from "@/styles/Custom";
-import { User, InfoItem } from "@/models/user.model";
+import { InfoItem } from "@/models/user.model";
 import MyInfoEdit from "@/components/MyInfoEdit";
 import NavBar from "@/components/NavBar";
 import { getUserInfo } from "@/api/user.api";
 import useUserStore from "@/store/userStore";
+import LogoutModal from "@/components/LogoutModal";
 
 const MyInfo = () => {
+  const [modalOpen, setModalOpen] = useState(false);
   // 로그인 구현하면 로그인 완료 시 개인정보 받아서 미리 저장하기
   const {
     user,
@@ -78,7 +80,10 @@ const MyInfo = () => {
                   return { ...info, value: data.birthdate };
                 case "성별":
                   setSex(data.sex);
-                  return { ...info, value: data.sex };
+                  return {
+                    ...info,
+                    value: data.sex === "MALE" ? "남성" : "여성",
+                  };
                 case "대화모드":
                   setMode(data.mode);
                   return {
@@ -142,12 +147,14 @@ const MyInfo = () => {
           <TouchableOpacity>
             <Text style={Custom.myTitle}>고객센터</Text>
           </TouchableOpacity>
-          <TouchableOpacity>
+          <TouchableOpacity onPress={() => setModalOpen(true)}>
             <Text style={Custom.myTitle}>로그아웃</Text>
           </TouchableOpacity>
         </View>
       </ScrollView>
       <NavBar type={"my"} />
+
+      {modalOpen && <LogoutModal setModalOpen={setModalOpen} />}
     </View>
   );
 };

--- a/src/components/KakaoBtn.tsx
+++ b/src/components/KakaoBtn.tsx
@@ -1,12 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 import { View, Text, TouchableOpacity, Image } from "react-native";
 import Custom from "@/styles/Custom";
 import { router } from "expo-router";
+import { login, logout } from "@react-native-seoul/kakao-login";
 
 const KakaoBtn = () => {
-  const handlePress = () => {
-    // 카카오 로그인 코드 추가하기
-    router.push("/formname");
+  const [result, setResult] = useState<string>("");
+
+  const signInWithKakao = async (): Promise<void> => {
+    try {
+      const token = await login();
+      setResult(JSON.stringify(token));
+      console.log("로그인 성공", token.accessToken);
+      router.push("/formname");
+    } catch (err) {
+      console.error("로그인 실패", err);
+    }
   };
 
   return (
@@ -24,7 +33,7 @@ const KakaoBtn = () => {
           marginBottom: 16,
           marginTop: 20,
         }}
-        onPress={handlePress}
+        onPress={signInWithKakao}
       >
         <Image
           style={{

--- a/src/components/LogoutModal.tsx
+++ b/src/components/LogoutModal.tsx
@@ -1,0 +1,79 @@
+import Custom from "@/styles/Custom";
+import ModalStyle from "@/styles/ModalStyle";
+import React, { useEffect } from "react";
+import { Image, Text, TouchableOpacity, View } from "react-native";
+import { logout } from "@react-native-seoul/kakao-login";
+import { router } from "expo-router";
+
+type ModalProps = {
+  setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const LogoutModal = ({ setModalOpen }: ModalProps) => {
+  const signOutWithKakao = async (): Promise<void> => {
+    try {
+      const message = await logout();
+      console.log(message);
+      router.push("/");
+    } catch (err) {
+      console.error("로그아웃 실패", err);
+    }
+  };
+
+  return (
+    <TouchableOpacity
+      onPress={() => setModalOpen(false)}
+      style={ModalStyle.outside}
+    >
+      <TouchableOpacity
+        onPress={(e) => e.stopPropagation()}
+        style={ModalStyle.logout}
+      >
+        <TouchableOpacity
+          onPress={() => setModalOpen(false)}
+          style={{
+            position: "absolute",
+            top: 16,
+            right: 16,
+          }}
+        >
+          <Image
+            style={{
+              width: 30,
+              height: 30,
+            }}
+            source={require("../../assets/images/close.png")}
+          />
+        </TouchableOpacity>
+        <View style={{ alignItems: "center", paddingTop: 24 }}>
+          <Text
+            style={{
+              fontFamily: "Pretendard-SemiBold",
+              fontSize: 13,
+            }}
+          >
+            로그아웃 하시겠습니까?
+          </Text>
+        </View>
+
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingHorizontal: 4,
+          }}
+        >
+          <TouchableOpacity onPress={signOutWithKakao}>
+            <Text style={ModalStyle.logoutbtn}>로그아웃</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => setModalOpen(false)}>
+            <Text style={ModalStyle.cancelbtn}>취소</Text>
+          </TouchableOpacity>
+        </View>
+      </TouchableOpacity>
+    </TouchableOpacity>
+  );
+};
+
+export default LogoutModal;

--- a/src/styles/ModalStyle.tsx
+++ b/src/styles/ModalStyle.tsx
@@ -80,6 +80,42 @@ const ModalStyle = StyleSheet.create({
     paddingHorizontal: 54,
     borderRadius: 32,
   },
+
+  // 로그아웃 모달창
+  logout: {
+    position: "absolute",
+    left: 25,
+    bottom: 250,
+    width: 310,
+    paddingHorizontal: 16,
+    paddingVertical: 32,
+    backgroundColor: "white",
+    borderWidth: 1,
+    borderColor: "#ddd",
+    borderRadius: 16,
+    gap: 30,
+  },
+
+  logoutbtn: {
+    fontFamily: "Pretendard-SemiBold",
+    fontSize: 12,
+    backgroundColor: "#5299FF",
+    color: "white",
+    paddingVertical: 12,
+    borderRadius: 32,
+    textAlign: "center",
+    minWidth: 125,
+  },
+
+  cancelbtn: {
+    fontFamily: "Pretendard-SemiBold",
+    fontSize: 12,
+    backgroundColor: "#EDEDEC",
+    paddingVertical: 12,
+    borderRadius: 32,
+    textAlign: "center",
+    minWidth: 125,
+  },
 });
 
 export default ModalStyle;


### PR DESCRIPTION
## 🔥 Issues
#11 

## ✅ What to do

- [x] 카카오로 계속하기 버튼 클릭 시 카카오 로그인 구현
- [x] 로그아웃 모달창 UI 
- [x] 카카오 로그아웃 구현

## 📄 Description
![Screenshot_20250303_231138_drivemate](https://github.com/user-attachments/assets/c427676b-3cd1-44bf-9ea5-5952dd99b953)

## 🤔 Considerations
myinfo 화면에서 로그아웃 버튼 클릭 시 모달창 생긴 후 로그아웃.
지금은 카카오 토큰으로 구현해서 아마 앱 자체 토큰 발급 시 수정할 수도.
백 구현 후 백이랑 얘기해봐야 할 듯.

카카오 로그인 -> 개인 정보 입력 페이지
1. 카카오 로그인만 하고 개인 정보 입력 화면 완성하지 못한 경우
status: 'unfinished'로 넘겨줌.
다음 로그인 시, 프론트에서 개인 정보 입력 화면으로 리다이렉트.

2. 카카오 로그인 후 개인 정보 입력까지 완성한 경우
status: 'finished'로 넘겨줌.
다음 로그인 시 프론트에서 메인 화면으로 리다이렉트.